### PR TITLE
Add D-Bus slot for GApplication

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,12 @@ description: |
 confinement: strict
 grade: stable
 
+slots:
+  dbus-shotwell:
+    interface: dbus
+    bus: session
+    name: org.yorba.shotwell
+
 apps:
   shotwell:
     command: desktop-launch shotwell --datadir $SNAP_USER_COMMON


### PR DESCRIPTION
GApplication-based snaps need a D-Bus slot, otherwise they won't start in confined mode